### PR TITLE
Se añade listener a la web para tomar el genero solo cuando se cambia para evitar el error

### DIFF
--- a/js/myscripts.js
+++ b/js/myscripts.js
@@ -90,8 +90,12 @@ var i="";
 //genero.oninput = function () {
 //  var r = document.querySelector("input[name=Sexo]:checked").value;
 //  paciente.sexo = r;
-  let gender = Array.from(document.getElementsByName("Sexo")).find(r => r.checked).value;
-paciente.sexo = gender;
+//@SMN947 -> Se añade listener a la web para tomar el genero solo cuando se cambia para evitar el error
+$(document).ready(function() {
+  $('input[type=radio][name="Sexo"]').change(function() {
+    paciente.sexo = $(this).val();
+  });
+});
 //};
 
 //genero.onclick = function(){


### PR DESCRIPTION
El error sucedía cuando se intenta leer el valor del elemento y aun no se ha renderizado.

Es por eso que al usar un listener se asegura que el elemento ya este en pantalla y adicionalmente se actualiza si se cambia la selección.

con esto se soluciona el error #16 